### PR TITLE
Track player troubleshoot

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -29,7 +29,7 @@
         "backgroundColor": "#F6F4CF"
       },
       "package": "com.adam.herrala.bricker.wedding",
-      "versionCode": 4
+      "versionCode": 5
     },
     "web": {
       "favicon": "./assets/minicon-32x32.png"

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -29,7 +29,7 @@
         "backgroundColor": "#F6F4CF"
       },
       "package": "com.adam.herrala.bricker.wedding",
-      "versionCode": 5
+      "versionCode": 7
     },
     "web": {
       "favicon": "./assets/minicon-32x32.png"

--- a/mobile/src/components/Main.js
+++ b/mobile/src/components/Main.js
@@ -11,6 +11,7 @@ import GridView from './GridView';
 import HighlightView from './HighlightView';
 import Music from './Music';
 import Welcome from './Welcome';
+import theme from '../theme';
 
 const styles = StyleSheet.create({
   container: {
@@ -20,7 +21,7 @@ const styles = StyleSheet.create({
   },
 
   loading: {
-    backgroundColor: '#CBDFBD',
+    backgroundColor: theme.color.loadingBG,
     flex: 1,
   },
 });
@@ -42,15 +43,25 @@ const Main = () => {
 
   // effect hook to initialize states
   useEffect(() => {
-    setupPlayer();
+    // try delaying the setup?
+    setTimeout(() => setupPlayer(), 5000);
     if (audioIsSetup) {
       dispatch(initializeMedia(entryToken, referer));
       dispatch(initializeScenes(entryToken, referer));
     }
   }, [entryToken]);
 
-  if (!audioIsSetup) return <View style = {styles.loading}></View>;
+  // show blank page while track play sets up
+  if (!audioIsSetup) {
+    return (
+      <View style = {styles.loading}>
+        <StatusBar
+          backgroundColor={theme.color.loadingBG}
+          barStyle={'dark-content'}/>
+      </View>);
+  }
 
+  // main view
   return (
     <View style = {styles.container}>
       <StatusBar backgroundColor={'#FAFAFA'} barStyle={'dark-content'}/>

--- a/mobile/src/components/Main.js
+++ b/mobile/src/components/Main.js
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
 import {Routes, Route, Navigate} from 'react-router-native';
-import {View, StyleSheet, StatusBar} from 'react-native';
+import {View, Text, StyleSheet, StatusBar} from 'react-native';
 import {useDispatch, useSelector} from 'react-redux';
 import {initializeMedia, setAudioIsSetup} from '../reducers/mediaReducer';
 import {initializeScenes} from '../reducers/sceneReducer';
@@ -27,12 +27,6 @@ const Main = () => {
   const referer = useSelector((i) => i.view.refPath);
   const audioIsSetup = useSelector((i) => i.media.audioIsSetup);
 
-  // effect hook to initialize states
-  useEffect(() => {
-    dispatch(initializeMedia(entryToken, referer));
-    dispatch(initializeScenes(entryToken, referer));
-  }, [entryToken]);
-
   // initial setup of track player
   const setupPlayer = async () => {
     if (!audioIsSetup) {
@@ -41,9 +35,16 @@ const Main = () => {
     }
   };
 
+  // effect hook to initialize states
   useEffect(() => {
     setupPlayer();
-  }, []);
+    if (audioIsSetup) {
+      dispatch(initializeMedia(entryToken, referer));
+      dispatch(initializeScenes(entryToken, referer));
+    }
+  }, [entryToken]);
+
+  if (!audioIsSetup) return <View><Text>setting up!</Text></View>;
 
   return (
     <View style = {styles.container}>

--- a/mobile/src/components/Main.js
+++ b/mobile/src/components/Main.js
@@ -43,7 +43,7 @@ const Main = () => {
 
   // effect hook to initialize states
   useEffect(() => {
-    // try delaying the setup?
+    // delay the setup to avoid a first-time startup issue
     setTimeout(() => setupPlayer(), 5000);
     if (audioIsSetup) {
       dispatch(initializeMedia(entryToken, referer));

--- a/mobile/src/components/Main.js
+++ b/mobile/src/components/Main.js
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
 import {Routes, Route, Navigate} from 'react-router-native';
-import {View, Text, StyleSheet, StatusBar} from 'react-native';
+import {View, StyleSheet, StatusBar} from 'react-native';
 import {useDispatch, useSelector} from 'react-redux';
 import {initializeMedia, setAudioIsSetup} from '../reducers/mediaReducer';
 import {initializeScenes} from '../reducers/sceneReducer';
@@ -17,6 +17,11 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     flexShrink: 1,
     alignItems: 'center',
+  },
+
+  loading: {
+    backgroundColor: '#CBDFBD',
+    flex: 1,
   },
 });
 
@@ -44,7 +49,7 @@ const Main = () => {
     }
   }, [entryToken]);
 
-  if (!audioIsSetup) return <View><Text>setting up!</Text></View>;
+  if (!audioIsSetup) return <View style = {styles.loading}></View>;
 
   return (
     <View style = {styles.container}>

--- a/mobile/src/theme.js
+++ b/mobile/src/theme.js
@@ -8,6 +8,7 @@ const theme = {
     accentDark: '#007E9D',
     light: '#E2E2E2',
     red: '#BA0042',
+    loadingBG: '#CBDFBD',
   },
 
   fontFamily: Platform.select({


### PR DESCRIPTION
The problems:
- The app consistently failed to load the very first time it was opened after download. After being closed and re-opened it would then load as expected.
- After sitting idle for a while, the app would crash and need to be restarted.
- Making things harder, neither behavior could be replicated in the development environment, so a new production build had to be uploaded/downloaded to the play store upon every change.

The apparent source of the problem:
- React Native Track Player needs `TrackPlayer.setupPlayer()` to run exactly once, before the track player is used for anything but after it's registered. The previous code was violating this at multiple points.

The fixes:
- A 5 second timeout was added in front of `setupPlayer()`, which seems to have solved the issue with failing to load on the very first opening. Presumably, this gives the app enough time to register the player.
- The app doesn't render until after `setupPlayer()` has been run, preventing users from clicking through to any features that call the track player prematurely. Instead, a blank screen is shown.
- Media initialization, which includes using the track player, can only happen after `setupPlayer()` has been called. This seems to have solved the issue of the player crashing when the app had been left idle for a while. I think it's likely that in these cases the app was trying to add tracks to the player before setup had concluded.
- (Previously) A state was added to keep track of whether `setupPlayer()` had been called, preventing repeat calls.
